### PR TITLE
Update Set-MyTimer.ps1 - if timer doesn't exist, prompt to create it.

### DIFF
--- a/functions/Set-MyTimer.ps1
+++ b/functions/Set-MyTimer.ps1
@@ -43,7 +43,18 @@ Function Set-MyTimer {
             } #foreach
         } #if $timers
         else {
-            Write-Warning "Can't find a matching timer object"
+            Write-Warning "Can't find a matching timer object. Would you like to create it?"
+            Switch (Read-Host  "y / n") {
+                y {
+                    Write-Verbose "[PROCESS] Creating timer $Name"
+                    $new = Start-MyTimer -Name $Name -Description $Description
+                    if ($start) {
+                        Write-Verbose "[PROCESS] Setting timer $Name start to $Start"
+                        Set-MyTimer -Name $Name -Start $Start
+                    }
+                    Get-MyTimer -Name $Name
+                }
+            }
         }
     } #process
 


### PR DESCRIPTION
On "can't find a matching timer" warning, prompt user to create it.  On yes, run Start-Mytimer using the provided params. Storing it in a variable to silence the output.  If the start param was set, also runs Set-Mytimer
Finally, runs Get-MyTimer to display the new timer.